### PR TITLE
Bump ubuntu version to 20.04

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:18.04
+FROM ubuntu:20.04
 MAINTAINER Matt Godbolt <matt@godbolt.org>
 
 ARG DEBIAN_FRONTEND=noninteractive


### PR DESCRIPTION
Building D requires a more recent host compiler and the gdc
used is based on GCC 7, but D hasn't been upstream before 9.
Bumping ubuntu version is an easy fix for that and probably
what we want anyway.

Signed-off-by: Marc Poulhiès <dkm@kataplop.net>