### PR TITLE
Enable objective-c and objective-c++

### DIFF
--- a/build/build.sh
+++ b/build/build.sh
@@ -4,7 +4,7 @@ set -ex
 
 ROOT=$(pwd)
 VERSION=$1
-LANGUAGES=c,c++,fortran,ada
+LANGUAGES=c,c++,fortran,ada,objc,obj-c++
 PLUGINS=
 BINUTILS_GITURL=https://sourceware.org/git/binutils-gdb.git
 BINUTILS_VERSION=2.38


### PR DESCRIPTION
Enable both langs in new builds of GCC.

refs https://github.com/compiler-explorer/compiler-explorer/issues/2942

Signed-off-by: Marc Poulhiès <dkm@kataplop.net>