### PR TITLE
Support for building external Cobol frontend for GCC

### DIFF
--- a/build/build.sh
+++ b/build/build.sh
@@ -71,6 +71,7 @@ elif echo "${VERSION}" | grep 'cobol-master'; then
     MAJOR_MINOR=13-trunk
     # Currently fails to build 32-bit multilibs
     MULTILIB_ENABLED=" --disable-multilib"
+    LANGUAGES=cobol
 elif echo "${VERSION}" | grep 'trunk'; then
     VERSION=trunk-$(date +%Y%m%d)
     URL=git://gcc.gnu.org/git/gcc.git

--- a/build/build.sh
+++ b/build/build.sh
@@ -10,6 +10,8 @@ BINUTILS_GITURL=https://sourceware.org/git/binutils-gdb.git
 BINUTILS_VERSION=2.38
 BINUTILS_REVISION=$BINUTILS_VERSION
 CONFIG=""
+MULTILIB_ENABLED="--enable-multilib"
+
 if echo "${VERSION}" | grep 'embed-trunk'; then
     VERSION=embed-trunk-$(date +%Y%m%d)
     URL=https://github.com/ThePhD/gcc.git
@@ -58,16 +60,23 @@ elif echo "${VERSION}" | grep 'gccrs-master'; then
     URL=https://github.com/Rust-GCC/gccrs.git
     BRANCH=master
     MAJOR=13
-    MAJOR_MINOR=11-trunk
+    MAJOR_MINOR=13-trunk
     # Only rust, this is intentional.
     LANGUAGES=rust
-    CONFIG+=" --enable-libstdcxx-backtrace=yes"
+elif echo "${VERSION}" | grep 'cobol-master'; then
+    VERSION=cobol-master-$(date +%Y%m%d)
+    URL=https://gitlab.cobolworx.com/COBOLworx/gcc-cobol.git
+    BRANCH="master+cobol"
+    MAJOR=13
+    MAJOR_MINOR=13-trunk
+    # Currently fails to build 32-bit multilibs
+    MULTILIB_ENABLED=" --disable-multilib"
 elif echo "${VERSION}" | grep 'trunk'; then
     VERSION=trunk-$(date +%Y%m%d)
     URL=git://gcc.gnu.org/git/gcc.git
     BRANCH=master
     MAJOR=13
-    MAJOR_MINOR=12-trunk
+    MAJOR_MINOR=13-trunk
     LANGUAGES="${LANGUAGES},go,d,rust,m2"
     CONFIG+=" --enable-libstdcxx-backtrace=yes"
 else
@@ -164,7 +173,7 @@ CONFIG+=" --disable-bootstrap"
 CONFIG+=" --enable-multiarch"
 CONFIG+=" --with-abi=m64"
 CONFIG+=" --with-multilib-list=m32,m64,mx32"
-CONFIG+=" --enable-multilib"
+CONFIG+=" ${MULTILIB_ENABLED}"
 CONFIG+=" --enable-clocale=gnu"
 CONFIG+=" --enable-languages=${LANGUAGES}"
 CONFIG+=" --enable-ld=yes"


### PR DESCRIPTION
Cobol frontend currently only lives in an external repository. It has been accepted in GCC upstream so will be also enabled in future release of GCC... But not there yet.

The compiler doesn't build for the 32-bits multilibs, so disable them for now.

refs https://github.com/compiler-explorer/compiler-explorer/issues/4893