### PR TITLE
Enable `<stacktrace>` support when building GCC 13

### DIFF
--- a/build/config/gcc13/enable_stacktrace
+++ b/build/config/gcc13/enable_stacktrace
@@ -1,0 +1,1 @@
+CONFIG+=" --enable-libstdcxx-backtrace=yes"


### PR DESCRIPTION
GCC 13 still requires `--enable-libstdcxx-backtrace=yes` to enable `<stacktrace>` support, but currently that flag is only set for `trunk` builds.

Repro: https://godbolt.org/z/4dnj7Kzsb