### PR TITLE
Add C++ dep on Cobol branch

### DIFF
--- a/build/build.sh
+++ b/build/build.sh
@@ -72,7 +72,8 @@ elif echo "${VERSION}" | grep 'cobol-master'; then
     MAJOR_MINOR=13-trunk
     # Currently fails to build 32-bit multilibs
     MULTILIB_ENABLED=" --disable-multilib"
-    LANGUAGES=cobol
+    ## implicit dep on C++ as libgcobol uses libstdc++.
+    LANGUAGES=cobol,c++
 elif echo "${VERSION}" | grep 'trunk'; then
     VERSION=trunk-$(date +%Y%m%d)
     URL=git://gcc.gnu.org/git/gcc.git


### PR DESCRIPTION
The libgcobol uses libstdc++ but the dep is not explicitely documented/handled in configure scripts.

Refs https://github.com/compiler-explorer/compiler-explorer/issues/5382