### PR TITLE
Enable backtrace for all release starting from 12

### DIFF
--- a/build/build.sh
+++ b/build/build.sh
@@ -104,6 +104,11 @@ else
     BRANCH=releases/gcc-${VERSION}
     if [[ "${MAJOR}" -gt 4 ]] || [[ "${MAJOR}" -eq 4 && "${MINOR}" -ge 7 ]]; then LANGUAGES=${LANGUAGES},go; fi
     if [[ "${MAJOR}" -ge 9 ]]; then LANGUAGES=${LANGUAGES},d; fi
+
+    # New for this explicit flag for enabling <backtrace> support.
+    # See https://github.com/compiler-explorer/compiler-explorer/issues/6103
+    if [[ "${MAJOR}" -ge 12 ]]; then CONFIG+=" --enable-libstdcxx-backtrace=yes"; fi
+
     # getting ready for next release.
     if [[ "${MAJOR}" -ge 13 ]]; then LANGUAGES=${LANGUAGES},m2; fi
 fi

--- a/build/config/gcc12/enable_stacktrace
+++ b/build/config/gcc12/enable_stacktrace
@@ -1,1 +1,0 @@
-CONFIG+=" --enable-libstdcxx-backtrace=yes"

--- a/build/config/gcc13/enable_stacktrace
+++ b/build/config/gcc13/enable_stacktrace
@@ -1,1 +1,0 @@
-CONFIG+=" --enable-libstdcxx-backtrace=yes"


### PR DESCRIPTION
Starting from GCC 12, the backtrace lib can be enabled with an explicit configure flag. It was added for gcc-12 and gcc-13 only (and only gcc-12 was built using it apparently). As we will need to add it for all future releases, better add this in the main script.

Refs https://github.com/compiler-explorer/compiler-explorer/issues/6103