### PR TITLE
fix env for build.sh wrt rust

### DIFF
--- a/build/build.sh
+++ b/build/build.sh
@@ -2,6 +2,11 @@
 
 set -ex
 
+# The Rust frontend needs cargo now (until it can build its rust deps, at some
+# point, someday, eventually)
+. "$HOME/.cargo/env"
+command -v cargo
+
 ROOT=$(pwd)
 VERSION=$1
 LANGUAGES=c,c++,fortran,ada,objc,obj-c++


### PR DESCRIPTION
Source the cargo env. Should be done in shell init, but for some reason
a docker noninteractive session doesn't source .profile/.bashrc.
Sourcing in build.sh makes it even more explicit that we need it.

refs https://github.com/compiler-explorer/compiler-explorer/issues/6201

Signed-off-by: Marc Poulhiès <dkm@kataplop.net>