### PR TITLE
Fix gcc 5.x build with modern g++ (wide-int.h patch + CE host compiler)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,6 +34,13 @@ RUN apt update -y -q && apt upgrade -y -q && apt upgrade -y -q && apt install -y
 ## The Rust frontend now requires rustc to build.
 RUN curl  --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | bash -s - -y
 
+# Install CE compilers for use as host when building old GCC versions.
+# Modern g++ (11+) is too strict for gcc 5.x-8.x source (C++17 changes,
+# stricter template rules). We use CE-built gcc 9.4.0 as host for MAJOR <= 8.
+RUN git clone --depth=1 https://github.com/compiler-explorer/infra /opt/compiler-explorer/infra && \
+    cd /opt/compiler-explorer/infra && make ce && \
+    /opt/compiler-explorer/infra/bin/ce_install install 'compilers/c++/x86/gcc 9.4.0'
+
 # We build from a directory that must be at least searchable with
 # EPERM on the CE nodes. Older GCCs erroneously search the $prefix
 # used during building, and if they hit a path that gives EPERM they

--- a/build/build.sh
+++ b/build/build.sh
@@ -308,6 +308,21 @@ applyPatchesAndConfig "gcc${MAJOR}"
 applyPatchesAndConfig "gcc${MAJOR_MINOR}"
 applyPatchesAndConfig "gcc${PATCH_VERSION:-$VERSION}"
 
+# For GCC 5-8, modern g++ (11+) is too strict (C++17 changes, stricter template
+# rules). Use a CE-installed gcc 9 as the host compiler instead if available.
+if [[ "${MAJOR}" =~ ^[0-9]+$ ]] && [[ "${MAJOR}" -le 8 ]]; then
+    CE_HOST_GCC=/opt/compiler-explorer/gcc-9.4.0
+    if [[ -d "${CE_HOST_GCC}" ]]; then
+        echo "Using CE gcc-9.4.0 as host compiler for gcc-${MAJOR}"
+        export PATH="${CE_HOST_GCC}/bin:${PATH}"
+        export LD_LIBRARY_PATH="${CE_HOST_GCC}/lib64:${CE_HOST_GCC}/lib:${LD_LIBRARY_PATH:-}"
+        export CC="${CE_HOST_GCC}/bin/gcc"
+        export CXX="${CE_HOST_GCC}/bin/g++"
+    else
+        echo "WARNING: CE gcc-9.4.0 not found at ${CE_HOST_GCC}, using system compiler"
+    fi
+fi
+
 echo "Will configure with ${CONFIG}"
 
 if [[ -z "${BINUTILS_VERSION}" ]]; then

--- a/build/build.sh
+++ b/build/build.sh
@@ -319,7 +319,8 @@ if [[ "${MAJOR}" =~ ^[0-9]+$ ]] && [[ "${MAJOR}" -le 8 ]]; then
         export CC="${CE_HOST_GCC}/bin/gcc"
         export CXX="${CE_HOST_GCC}/bin/g++"
     else
-        echo "WARNING: CE gcc-9.4.0 not found at ${CE_HOST_GCC}, using system compiler"
+        echo "ERROR: CE gcc-9.4.0 not found at ${CE_HOST_GCC} (required to build gcc ${MAJOR})"
+        exit 1
     fi
 fi
 

--- a/build/patches/gcc5/wide-int-modern-cxx.patch
+++ b/build/patches/gcc5/wide-int-modern-cxx.patch
@@ -1,0 +1,90 @@
+--- a/gcc/wide-int.h	2026-03-10 11:09:37.039823467 -0500
++++ b/gcc/wide-int.h	2026-03-10 11:23:13.036262233 -0500
+@@ -365,21 +365,18 @@
+      inputs.  Note that CONST_PRECISION and VAR_PRECISION cannot be
+      mixed, in order to give stronger type checking.  When both inputs
+      are CONST_PRECISION, they must have the same precision.  */
+-  template <>
+   template <typename T1, typename T2>
+   struct binary_traits <T1, T2, FLEXIBLE_PRECISION, FLEXIBLE_PRECISION>
+   {
+     typedef widest_int result_type;
+   };
+ 
+-  template <>
+   template <typename T1, typename T2>
+   struct binary_traits <T1, T2, FLEXIBLE_PRECISION, VAR_PRECISION>
+   {
+     typedef wide_int result_type;
+   };
+ 
+-  template <>
+   template <typename T1, typename T2>
+   struct binary_traits <T1, T2, FLEXIBLE_PRECISION, CONST_PRECISION>
+   {
+@@ -389,14 +386,12 @@
+ 			       <int_traits <T2>::precision> > result_type;
+   };
+ 
+-  template <>
+   template <typename T1, typename T2>
+   struct binary_traits <T1, T2, VAR_PRECISION, FLEXIBLE_PRECISION>
+   {
+     typedef wide_int result_type;
+   };
+ 
+-  template <>
+   template <typename T1, typename T2>
+   struct binary_traits <T1, T2, CONST_PRECISION, FLEXIBLE_PRECISION>
+   {
+@@ -406,7 +401,6 @@
+ 			       <int_traits <T1>::precision> > result_type;
+   };
+ 
+-  template <>
+   template <typename T1, typename T2>
+   struct binary_traits <T1, T2, CONST_PRECISION, CONST_PRECISION>
+   {
+@@ -417,7 +411,6 @@
+ 			       <int_traits <T1>::precision> > result_type;
+   };
+ 
+-  template <>
+   template <typename T1, typename T2>
+   struct binary_traits <T1, T2, VAR_PRECISION, VAR_PRECISION>
+   {
+@@ -881,7 +874,6 @@
+ 
+ namespace wi
+ {
+-  template <>
+   template <typename storage>
+   struct int_traits < generic_wide_int <storage> >
+     : public wi::int_traits <storage>
+@@ -960,7 +952,6 @@
+ 
+ namespace wi
+ {
+-  template <>
+   template <bool SE>
+   struct int_traits <wide_int_ref_storage <SE> >
+   {
+@@ -1147,7 +1138,6 @@
+ 
+ namespace wi
+ {
+-  template <>
+   template <int N>
+   struct int_traits < fixed_wide_int_storage <N> >
+   {
+@@ -2902,7 +2892,9 @@
+ 	 For variable-precision integers like wide_int, handle HWI
+ 	 and sub-HWI integers inline.  */
+       if (STATIC_CONSTANT_P (xi.precision > HOST_BITS_PER_WIDE_INT)
+-	  ? xi.len == 1 && xi.val[0] >= 0
++	  ? (shift < HOST_BITS_PER_WIDE_INT
++	     && xi.len == 1
++	     && xi.val[0] >= 0)
+ 	  : xi.precision <= HOST_BITS_PER_WIDE_INT)
+ 	{
+ 	  val[0] = xi.to_uhwi () >> shift;


### PR DESCRIPTION
*(I'm Molty, an AI assistant acting on behalf of @mattgodbolt)*

Combines the CE host compiler setup (from the separately-merged PR #37) with a source patch for gcc 5.x.

## What's in this PR

### 1. wide-int.h patch for gcc 5.1–5.4
gcc 5.1.0–5.4.0 have spurious `template <>` annotations on partial specializations in `wide-int.h`, which any g++ ≥ 6 rejects with `too many template-parameter-lists`. The fix was applied in gcc 5.5.0. This patch backports it.

Generated by diffing `gcc-5.1.0` vs `gcc-5.5.0` tags: only the `template <>` removals and one minor logic fix are included.

### 2. CE gcc-9.4.0 as host + hard error if missing
(Already merged in PR #37 — this branch includes those changes.)

## Testing
- gcc 5.1.0, 5.2.0 both failed without this patch even with CE gcc-9.4.0 as host
- gcc 5.4.0 and 6.1.0 canary builds triggered (results pending)
- Once this is merged and Docker image rebuilt, will retry 5.1.0 as the critical canary