### PR TITLE
Fix Ada gnat bootstrap incompatibility and cfns/libgo build failures (gcc 5-10)

### DIFF
--- a/build/build.sh
+++ b/build/build.sh
@@ -324,6 +324,28 @@ if [[ "${MAJOR}" =~ ^[0-9]+$ ]] && [[ "${MAJOR}" -le 8 ]]; then
     fi
 fi
 
+# For GCC 5-10, the system gnat (gnat-11 on Ubuntu 22.04) uses Ada runtime
+# interfaces introduced in GCC 11 (e.g. SS_Stack, __gnat_begin_handler_v1)
+# that older gcc Ada runtimes don't provide.  The build system looks for the
+# cross-triple-prefixed x86_64-linux-gnu-gnatbind from gnat-11, so we shadow
+# it with wrappers pointing to CE gcc-9.4.0's gnat tools, which are compatible
+# with the gcc 5-10 Ada runtimes.
+if [[ "${MAJOR}" =~ ^[0-9]+$ ]] && [[ "${MAJOR}" -le 10 ]]; then
+    CE_HOST_GCC=/opt/compiler-explorer/gcc-9.4.0
+    if [[ -d "${CE_HOST_GCC}/bin/gnatbind" ]] || [[ -f "${CE_HOST_GCC}/bin/gnatbind" ]]; then
+        echo "Wrapping system gnat with CE gcc-9.4.0 gnat tools for Ada bootstrap of gcc-${MAJOR}"
+        GNAT_WRAPPER_DIR="$(mktemp -d)"
+        for tool in gnat gnatbind gnatclean gnatfind gnatchop gnatkr gnatlink gnatls gnatmake gnatname gnatprep gnatxref; do
+            if [[ -f "${CE_HOST_GCC}/bin/${tool}" ]]; then
+                ln -sf "${CE_HOST_GCC}/bin/${tool}" "${GNAT_WRAPPER_DIR}/x86_64-linux-gnu-${tool}"
+            fi
+        done
+        export PATH="${GNAT_WRAPPER_DIR}:${PATH}"
+    else
+        echo "WARNING: CE gcc-9.4.0 gnat tools not found; Ada bootstrap may fail for gcc-${MAJOR}"
+    fi
+fi
+
 echo "Will configure with ${CONFIG}"
 
 if [[ -z "${BINUTILS_VERSION}" ]]; then

--- a/build/patches/gcc10.1/libgo-sigstksz-cast.patch
+++ b/build/patches/gcc10.1/libgo-sigstksz-cast.patch
@@ -1,0 +1,1 @@
+../libgo-sigstksz-cast.patch

--- a/build/patches/gcc10.2/libgo-sigstksz-cast.patch
+++ b/build/patches/gcc10.2/libgo-sigstksz-cast.patch
@@ -1,0 +1,1 @@
+../libgo-sigstksz-cast.patch

--- a/build/patches/gcc5/cfns.patch
+++ b/build/patches/gcc5/cfns.patch
@@ -1,0 +1,1 @@
+../cfns.patch

--- a/build/patches/libgo-sigstksz-cast.patch
+++ b/build/patches/libgo-sigstksz-cast.patch
@@ -1,0 +1,12 @@
+--- a/libgo/runtime/proc.c
++++ b/libgo/runtime/proc.c
+@@ -799,8 +799,8 @@ newg_from_sp_locked(G *gp, bool allocatestack, bool signalstack, byte** ret_sta
+ 		if(signalstack) {
+ 			stacksize = 32 * 1024; // OS X wants >= 8K, GNU/Linux >= 2K
+ #ifdef SIGSTKSZ
+-			if(stacksize < SIGSTKSZ)
+-				stacksize = SIGSTKSZ;
++			if(stacksize < (uintptr)(SIGSTKSZ))
++				stacksize = (uintptr)(SIGSTKSZ);
+ #endif
+ 		}


### PR DESCRIPTION
Fixes remaining build failures seen in canary runs after PR #40.

## Issues fixed

### 1. cfns.gperf gnu_inline redeclaration (gcc 5.x)
Add symlink `build/patches/gcc5/cfns.patch` pointing to the existing top-level `cfns.patch`.
gcc 5.x has the same `libc_name_p` redeclared-with-gnu_inline issue as gcc 4.x; gcc 6+ fixed it.

### 2. Ada bootstrap incompatibility — system gnat-11 vs gcc 5–10 runtime (big fix)
When building Ada for gcc 5–10, the build looks for `x86_64-linux-gnu-gnatbind` and finds the
system gnat-11. But gnat-11 generates Ada bootstrap code (`b_gnat1.adb`) referencing interfaces
introduced in GCC 11:
- Refactored Secondary_Stack (`SS_Stack` type) — not in gcc 5–10's `s-secsta.ads`
- `__gnat_begin_handler_v1` exception handlers — not in gcc 5–10's Ada runtime library

Fix: in `build.sh`, for MAJOR ≤ 10, create a temp dir of `x86_64-linux-gnu-gnat*` symlinks
pointing to CE gcc-9.4.0's gnat tools (which are pre-GCC-11 and compatible with old runtimes)
and prepend it to PATH before the build.

### 3. libgo sign-compare (gcc 10.1.0 and 10.2.0 only)
`libgo/runtime/proc.c:802`: compares `uintptr` against `SIGSTKSZ` (`long int`), triggering
`-Werror=sign-compare` with g++11. Fixed in 10.3.0 already.
Fix: add `libgo-sigstksz-cast.patch` with `(uintptr)(SIGSTKSZ)` casts, symlinked in `gcc10.1/` and `gcc10.2/`.

🤖 Generated by LLM (Claude, via OpenClaw)