### PR TITLE
Fix Ada gnat bootstrap and libgo/cfns failures for gcc 5-10

### DIFF
--- a/build/build.sh
+++ b/build/build.sh
@@ -342,7 +342,8 @@ if [[ "${MAJOR}" =~ ^[0-9]+$ ]] && [[ "${MAJOR}" -le 10 ]]; then
         done
         export PATH="${GNAT_WRAPPER_DIR}:${PATH}"
     else
-        echo "WARNING: CE gcc-9.4.0 gnat tools not found; Ada bootstrap may fail for gcc-${MAJOR}"
+        echo "ERROR: CE gcc-9.4.0 gnat tools not found at ${CE_HOST_GCC} (required for Ada bootstrap of gcc-${MAJOR})"
+        exit 1
     fi
 fi
 

--- a/build/build.sh
+++ b/build/build.sh
@@ -324,6 +324,28 @@ if [[ "${MAJOR}" =~ ^[0-9]+$ ]] && [[ "${MAJOR}" -le 8 ]]; then
     fi
 fi
 
+# For GCC 5-10, the system gnat (gnat-11 on Ubuntu 22.04) uses Ada runtime
+# interfaces introduced in GCC 11 (e.g. SS_Stack, __gnat_begin_handler_v1)
+# that older gcc Ada runtimes don't provide.  The build system looks for the
+# cross-triple-prefixed x86_64-linux-gnu-gnatbind from gnat-11, so we shadow
+# it with wrappers pointing to CE gcc-9.4.0's gnat tools, which are compatible
+# with the gcc 5-10 Ada runtimes.
+if [[ "${MAJOR}" =~ ^[0-9]+$ ]] && [[ "${MAJOR}" -le 10 ]]; then
+    CE_HOST_GCC=/opt/compiler-explorer/gcc-9.4.0
+    if [[ -d "${CE_HOST_GCC}/bin/gnatbind" ]] || [[ -f "${CE_HOST_GCC}/bin/gnatbind" ]]; then
+        echo "Wrapping system gnat with CE gcc-9.4.0 gnat tools for Ada bootstrap of gcc-${MAJOR}"
+        GNAT_WRAPPER_DIR="$(mktemp -d)"
+        for tool in gnat gnatbind gnatclean gnatfind gnatchop gnatkr gnatlink gnatls gnatmake gnatname gnatprep gnatxref; do
+            if [[ -f "${CE_HOST_GCC}/bin/${tool}" ]]; then
+                ln -sf "${CE_HOST_GCC}/bin/${tool}" "${GNAT_WRAPPER_DIR}/x86_64-linux-gnu-${tool}"
+            fi
+        done
+        export PATH="${GNAT_WRAPPER_DIR}:${PATH}"
+    else
+        echo "WARNING: CE gcc-9.4.0 gnat tools not found; Ada bootstrap may fail for gcc-${MAJOR}"
+    fi
+fi
+
 echo "Will configure with ${CONFIG}"
 
 if [[ -z "${BINUTILS_VERSION}" ]]; then

--- a/build/patches/gcc10.1/libgo-sigstksz-cast.patch
+++ b/build/patches/gcc10.1/libgo-sigstksz-cast.patch
@@ -1,0 +1,1 @@
+../libgo-sigstksz-cast.patch

--- a/build/patches/gcc10.2/libgo-sigstksz-cast.patch
+++ b/build/patches/gcc10.2/libgo-sigstksz-cast.patch
@@ -1,0 +1,1 @@
+../libgo-sigstksz-cast.patch

--- a/build/patches/gcc5/cfns.patch
+++ b/build/patches/gcc5/cfns.patch
@@ -1,0 +1,1 @@
+../cfns.patch

--- a/build/patches/libgo-sigstksz-cast.patch
+++ b/build/patches/libgo-sigstksz-cast.patch
@@ -1,0 +1,12 @@
+--- a/libgo/runtime/proc.c
++++ b/libgo/runtime/proc.c
+@@ -799,8 +799,8 @@ newg_from_sp_locked(G *gp, bool allocatestack, bool signalstack, byte** ret_sta
+ 		if(signalstack) {
+ 			stacksize = 32 * 1024; // OS X wants >= 8K, GNU/Linux >= 2K
+ #ifdef SIGSTKSZ
+-			if(stacksize < SIGSTKSZ)
+-				stacksize = SIGSTKSZ;
++			if(stacksize < (uintptr)(SIGSTKSZ))
++				stacksize = (uintptr)(SIGSTKSZ);
+ #endif
+ 		}


### PR DESCRIPTION
Follow-up to #40.

**Problems fixed:**

**1. Ada bootstrap incompatibility (gcc 5–10)**
System gnat-11 (`x86_64-linux-gnu-gnatbind`) generates Ada bootstrap code using GCC 11-style runtime interfaces that gcc 5–10 runtimes don't provide:
- Secondary_Stack refactored → `SS_Stack` type (not in gcc 5–10's `s-secsta.ads`)
- `__gnat_begin_handler_v1` exception handlers (not in gcc 5–10 Ada runtime)

Fix: for MAJOR ≤ 10, create `x86_64-linux-gnu-gnat*` symlinks in a temp dir pointing to CE gcc-9.4.0's gnat tools (pre-GCC-11, compatible with old runtimes), prepend to PATH.

**2. cfns.gperf gnu_inline redeclaration (gcc 5.x)**
gcc 5.x has `__inline` without `gnu_inline` guard in `cfns.gperf`/`cfns.h`, rejected by modern g++. Existing `cfns.patch` already existed — added symlink in `gcc5/` dir.

**3. libgo sign-compare (gcc 10.1 and 10.2 only)**
`libgo/runtime/proc.c:802`: compares `uintptr` against `SIGSTKSZ` (`long int`), triggering `-Werror=sign-compare`. Already fixed in 10.3.0 with `(uintptr)(SIGSTKSZ)` casts.

🤖 Generated by LLM (Claude, via OpenClaw)