### PR TITLE
Fix Ada bootstrap for gcc 5-10 using version-matched CE gnat hosts

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,11 +35,13 @@ RUN apt update -y -q && apt upgrade -y -q && apt upgrade -y -q && apt install -y
 RUN curl  --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | bash -s - -y
 
 # Install CE compilers for use as host when building old GCC versions.
-# Modern g++ (11+) is too strict for gcc 5.x-8.x source (C++17 changes,
-# stricter template rules). We use CE-built gcc 9.4.0 as host for MAJOR <= 8.
+# - gcc 9.4.0: C/C++ host for MAJOR <= 10 (modern g++ 11+ too strict for old GCC source)
+# - gcc 8.5.0: Ada (gnat) host for MAJOR <= 8 (gcc 9.4.0's gnat uses SS_Stack which
+#   gcc 5-8 Ada runtimes don't have; gcc 8.5.0's gnat predates that interface)
 RUN git clone --depth=1 https://github.com/compiler-explorer/infra /opt/compiler-explorer/infra && \
     cd /opt/compiler-explorer/infra && make ce && \
-    /opt/compiler-explorer/infra/bin/ce_install install 'compilers/c++/x86/gcc 9.4.0'
+    /opt/compiler-explorer/infra/bin/ce_install install 'compilers/c++/x86/gcc 9.4.0' && \
+    /opt/compiler-explorer/infra/bin/ce_install install 'compilers/c++/x86/gcc 8.5.0'
 
 # We build from a directory that must be at least searchable with
 # EPERM on the CE nodes. Older GCCs erroneously search the $prefix

--- a/build/build.sh
+++ b/build/build.sh
@@ -308,12 +308,12 @@ applyPatchesAndConfig "gcc${MAJOR}"
 applyPatchesAndConfig "gcc${MAJOR_MINOR}"
 applyPatchesAndConfig "gcc${PATCH_VERSION:-$VERSION}"
 
-# For GCC 5-8, modern g++ (11+) is too strict (C++17 changes, stricter template
-# rules). Use a CE-installed gcc 9 as the host compiler instead if available.
-if [[ "${MAJOR}" =~ ^[0-9]+$ ]] && [[ "${MAJOR}" -le 8 ]]; then
+# For GCC 5-10, modern g++ (11+) is too strict (C++17 changes, stricter template
+# rules). Use a CE-installed gcc 9.4.0 as the C/C++ host compiler.
+if [[ "${MAJOR}" =~ ^[0-9]+$ ]] && [[ "${MAJOR}" -le 10 ]]; then
     CE_HOST_GCC=/opt/compiler-explorer/gcc-9.4.0
     if [[ -d "${CE_HOST_GCC}" ]]; then
-        echo "Using CE gcc-9.4.0 as host compiler for gcc-${MAJOR}"
+        echo "Using CE gcc-9.4.0 as host C/C++ compiler for gcc-${MAJOR}"
         export PATH="${CE_HOST_GCC}/bin:${PATH}"
         export LD_LIBRARY_PATH="${CE_HOST_GCC}/lib64:${CE_HOST_GCC}/lib:${LD_LIBRARY_PATH:-}"
         export CC="${CE_HOST_GCC}/bin/gcc"
@@ -324,25 +324,28 @@ if [[ "${MAJOR}" =~ ^[0-9]+$ ]] && [[ "${MAJOR}" -le 8 ]]; then
     fi
 fi
 
-# For GCC 5-10, the system gnat (gnat-11 on Ubuntu 22.04) uses Ada runtime
-# interfaces introduced in GCC 11 (e.g. SS_Stack, __gnat_begin_handler_v1)
-# that older gcc Ada runtimes don't provide.  The build system looks for the
-# cross-triple-prefixed x86_64-linux-gnu-gnatbind from gnat-11, so we shadow
-# it with wrappers pointing to CE gcc-9.4.0's gnat tools, which are compatible
-# with the gcc 5-10 Ada runtimes.
+# For GCC 5-10, the system gnat (gnat-11) uses Ada runtime interfaces not present
+# in older gcc Ada runtimes (__gnat_begin_handler_v1, SS_Stack).  Shadow the
+# cross-triple-prefixed gnat tools with CE versions that are ABI-compatible:
+#   - MAJOR <= 8: use CE gcc-8.5.0 gnat (predates SS_Stack; compatible with gcc 5-8)
+#   - MAJOR 9-10: use CE gcc-9.4.0 gnat (no __gnat_begin_handler_v1; compatible with gcc 9-10)
 if [[ "${MAJOR}" =~ ^[0-9]+$ ]] && [[ "${MAJOR}" -le 10 ]]; then
-    CE_HOST_GCC=/opt/compiler-explorer/gcc-9.4.0
-    if [[ -d "${CE_HOST_GCC}/bin/gnatbind" ]] || [[ -f "${CE_HOST_GCC}/bin/gnatbind" ]]; then
-        echo "Wrapping system gnat with CE gcc-9.4.0 gnat tools for Ada bootstrap of gcc-${MAJOR}"
+    if [[ "${MAJOR}" -le 8 ]]; then
+        CE_ADA_GCC=/opt/compiler-explorer/gcc-8.5.0
+    else
+        CE_ADA_GCC=/opt/compiler-explorer/gcc-9.4.0
+    fi
+    if [[ -f "${CE_ADA_GCC}/bin/gnatbind" ]]; then
+        echo "Using CE gcc-${CE_ADA_GCC##*-} gnat tools for Ada bootstrap of gcc-${MAJOR}"
         GNAT_WRAPPER_DIR="$(mktemp -d)"
         for tool in gnat gnatbind gnatclean gnatfind gnatchop gnatkr gnatlink gnatls gnatmake gnatname gnatprep gnatxref; do
-            if [[ -f "${CE_HOST_GCC}/bin/${tool}" ]]; then
-                ln -sf "${CE_HOST_GCC}/bin/${tool}" "${GNAT_WRAPPER_DIR}/x86_64-linux-gnu-${tool}"
+            if [[ -f "${CE_ADA_GCC}/bin/${tool}" ]]; then
+                ln -sf "${CE_ADA_GCC}/bin/${tool}" "${GNAT_WRAPPER_DIR}/x86_64-linux-gnu-${tool}"
             fi
         done
         export PATH="${GNAT_WRAPPER_DIR}:${PATH}"
     else
-        echo "ERROR: CE gcc-9.4.0 gnat tools not found at ${CE_HOST_GCC} (required for Ada bootstrap of gcc-${MAJOR})"
+        echo "ERROR: CE gnat tools not found at ${CE_ADA_GCC} (required for Ada bootstrap of gcc-${MAJOR})"
         exit 1
     fi
 fi


### PR DESCRIPTION
System gnat-11 is ABI-incompatible with older gcc Ada runtimes in two ways:
- Generates `__gnat_begin_handler_v1` calls (introduced in gcc 11) — not in gcc 9-10 runtime
- Generates SS_Stack-style secondary stack init (introduced in gcc 9.4.0) — not in gcc 5-8 runtime

**Changes:**

`Dockerfile`: also install CE gcc-8.5.0 alongside gcc-9.4.0

`build.sh`:
- Extend `CC/CXX = CE gcc-9.4.0` from MAJOR ≤ 8 to MAJOR ≤ 10 (fixes C++ host for gcc 9-10 too)
- For MAJOR ≤ 10: shadow `x86_64-linux-gnu-gnat*` with CE gcc-9.4.0 gnat tools (no `_v1` handler; compatible with gcc 9-10 Ada runtime)
- For MAJOR ≤ 8: override to CE gcc-8.5.0 gnat tools instead (predates SS_Stack; compatible with gcc 5-8 Ada runtime)

🤖 Generated by LLM (Claude, via OpenClaw)