### PR TITLE
Simplify host compiler setup: one block, one CE_HOST_GCC variable

### DIFF
--- a/build/build.sh
+++ b/build/build.sh
@@ -308,46 +308,35 @@ applyPatchesAndConfig "gcc${MAJOR}"
 applyPatchesAndConfig "gcc${MAJOR_MINOR}"
 applyPatchesAndConfig "gcc${PATCH_VERSION:-$VERSION}"
 
-# For GCC 5-10, modern g++ (11+) is too strict (C++17 changes, stricter template
-# rules). Use a CE-installed gcc 9.4.0 as the C/C++ host compiler.
-if [[ "${MAJOR}" =~ ^[0-9]+$ ]] && [[ "${MAJOR}" -le 10 ]]; then
-    CE_HOST_GCC=/opt/compiler-explorer/gcc-9.4.0
-    if [[ -d "${CE_HOST_GCC}" ]]; then
-        echo "Using CE gcc-9.4.0 as host C/C++ compiler for gcc-${MAJOR}"
-        export PATH="${CE_HOST_GCC}/bin:${PATH}"
-        export LD_LIBRARY_PATH="${CE_HOST_GCC}/lib64:${CE_HOST_GCC}/lib:${LD_LIBRARY_PATH:-}"
-        export CC="${CE_HOST_GCC}/bin/gcc"
-        export CXX="${CE_HOST_GCC}/bin/g++"
-    else
-        echo "ERROR: CE gcc-9.4.0 not found at ${CE_HOST_GCC} (required to build gcc ${MAJOR})"
-        exit 1
-    fi
-fi
-
-# For GCC 5-10, the system gnat (gnat-11) uses Ada runtime interfaces not present
-# in older gcc Ada runtimes (__gnat_begin_handler_v1, SS_Stack).  Shadow the
-# cross-triple-prefixed gnat tools with CE versions that are ABI-compatible:
-#   - MAJOR <= 8: use CE gcc-8.5.0 gnat (predates SS_Stack; compatible with gcc 5-8)
-#   - MAJOR 9-10: use CE gcc-9.4.0 gnat (no __gnat_begin_handler_v1; compatible with gcc 9-10)
+# For GCC 5-10, the system compiler (gcc-11+) and system gnat are incompatible
+# with older GCC source and Ada runtimes.  Pick a CE-installed host GCC whose
+# C++ and Ada (gnat1/gnatbind) are ABI-compatible with the version being built:
+#   MAJOR <= 8 : gcc-8.5.0  (C++ host + gnat; predates SS_Stack Ada interface)
+#   MAJOR 9-10 : gcc-9.4.0  (C++ host + gnat; no __gnat_begin_handler_v1)
 if [[ "${MAJOR}" =~ ^[0-9]+$ ]] && [[ "${MAJOR}" -le 10 ]]; then
     if [[ "${MAJOR}" -le 8 ]]; then
-        CE_ADA_GCC=/opt/compiler-explorer/gcc-8.5.0
+        CE_HOST_GCC=/opt/compiler-explorer/gcc-8.5.0
     else
-        CE_ADA_GCC=/opt/compiler-explorer/gcc-9.4.0
+        CE_HOST_GCC=/opt/compiler-explorer/gcc-9.4.0
     fi
-    if [[ -f "${CE_ADA_GCC}/bin/gnatbind" ]]; then
-        echo "Using CE gcc-${CE_ADA_GCC##*-} gnat tools for Ada bootstrap of gcc-${MAJOR}"
-        GNAT_WRAPPER_DIR="$(mktemp -d)"
-        for tool in gnat gnatbind gnatclean gnatfind gnatchop gnatkr gnatlink gnatls gnatmake gnatname gnatprep gnatxref; do
-            if [[ -f "${CE_ADA_GCC}/bin/${tool}" ]]; then
-                ln -sf "${CE_ADA_GCC}/bin/${tool}" "${GNAT_WRAPPER_DIR}/x86_64-linux-gnu-${tool}"
-            fi
-        done
-        export PATH="${GNAT_WRAPPER_DIR}:${PATH}"
-    else
-        echo "ERROR: CE gnat tools not found at ${CE_ADA_GCC} (required for Ada bootstrap of gcc-${MAJOR})"
+    if [[ ! -d "${CE_HOST_GCC}" ]]; then
+        echo "ERROR: CE host gcc not found at ${CE_HOST_GCC} (required to build gcc ${MAJOR})"
         exit 1
     fi
+    echo "Using CE ${CE_HOST_GCC##*/} as host for gcc-${MAJOR}"
+    export PATH="${CE_HOST_GCC}/bin:${PATH}"
+    export LD_LIBRARY_PATH="${CE_HOST_GCC}/lib64:${CE_HOST_GCC}/lib:${LD_LIBRARY_PATH:-}"
+    export CC="${CE_HOST_GCC}/bin/gcc"
+    export CXX="${CE_HOST_GCC}/bin/g++"
+    # Shadow x86_64-linux-gnu-gnat* with the host's gnat tools so the Ada
+    # bootstrap uses the same gnat version as the C/C++ host above.
+    GNAT_WRAPPER_DIR="$(mktemp -d)"
+    for tool in gnat gnatbind gnatclean gnatfind gnatchop gnatkr gnatlink gnatls gnatmake gnatname gnatprep gnatxref; do
+        if [[ -f "${CE_HOST_GCC}/bin/${tool}" ]]; then
+            ln -sf "${CE_HOST_GCC}/bin/${tool}" "${GNAT_WRAPPER_DIR}/x86_64-linux-gnu-${tool}"
+        fi
+    done
+    export PATH="${GNAT_WRAPPER_DIR}:${PATH}"
 fi
 
 echo "Will configure with ${CONFIG}"


### PR DESCRIPTION
Replaces the two-block approach (separate C/C++ host block + separate gnat wrapper block) with a single unified block.

Pick one CE host GCC per version band; CC, CXX, PATH, LD_LIBRARY_PATH, and `x86_64-linux-gnu-gnat*` wrappers all derive from it:

- **MAJOR ≤ 8** → `gcc-8.5.0` (C++ host + gnat; predates SS_Stack Ada interface)
- **MAJOR 9–10** → `gcc-9.4.0` (C++ host + gnat; no `__gnat_begin_handler_v1`)

Since Ada source files are compiled via `CC -x ada`, using a single host for both C/C++ and Ada ensures the correct gnat1 is used throughout — wrapper-only approaches only affect standalone gnat tools, not Ada compilation driven through CC.

🤖 Generated by LLM (Claude, via OpenClaw)