### PR TITLE
Use gcc-7.5.0/8.5.0 as host compilers with correct version bands

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,12 +35,13 @@ RUN apt update -y -q && apt upgrade -y -q && apt upgrade -y -q && apt install -y
 RUN curl  --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | bash -s - -y
 
 # Install CE compilers for use as host when building old GCC versions.
-# - gcc 9.4.0: C/C++ host for MAJOR <= 10 (modern g++ 11+ too strict for old GCC source)
-# - gcc 8.5.0: Ada (gnat) host for MAJOR <= 8 (gcc 9.4.0's gnat uses SS_Stack which
-#   gcc 5-8 Ada runtimes don't have; gcc 8.5.0's gnat predates that interface)
+# SS_Stack was introduced in gcc 8's Ada runtime and bindgen.adb; __gnat_begin_handler_v1
+# was introduced in gcc 11.  So:
+#   MAJOR <= 7 : gcc-7.5.0 host (bindgen predates SS_Stack; compatible with gcc 5-7)
+#   MAJOR 8-10 : gcc-8.5.0 host (bindgen has SS_Stack; no __gnat_begin_handler_v1)
 RUN git clone --depth=1 https://github.com/compiler-explorer/infra /opt/compiler-explorer/infra && \
     cd /opt/compiler-explorer/infra && make ce && \
-    /opt/compiler-explorer/infra/bin/ce_install install 'compilers/c++/x86/gcc 9.4.0' && \
+    /opt/compiler-explorer/infra/bin/ce_install install 'compilers/c++/x86/gcc 7.5.0' && \
     /opt/compiler-explorer/infra/bin/ce_install install 'compilers/c++/x86/gcc 8.5.0'
 
 # We build from a directory that must be at least searchable with

--- a/build/build.sh
+++ b/build/build.sh
@@ -311,13 +311,13 @@ applyPatchesAndConfig "gcc${PATCH_VERSION:-$VERSION}"
 # For GCC 5-10, the system compiler (gcc-11+) and system gnat are incompatible
 # with older GCC source and Ada runtimes.  Pick a CE-installed host GCC whose
 # C++ and Ada (gnat1/gnatbind) are ABI-compatible with the version being built:
-#   MAJOR <= 8 : gcc-8.5.0  (C++ host + gnat; predates SS_Stack Ada interface)
-#   MAJOR 9-10 : gcc-9.4.0  (C++ host + gnat; no __gnat_begin_handler_v1)
+#   MAJOR <= 7 : gcc-7.5.0  (bindgen predates SS_Stack; compatible with gcc 5-7 Ada)
+#   MAJOR 8-10 : gcc-8.5.0  (bindgen has SS_Stack; no __gnat_begin_handler_v1)
 if [[ "${MAJOR}" =~ ^[0-9]+$ ]] && [[ "${MAJOR}" -le 10 ]]; then
-    if [[ "${MAJOR}" -le 8 ]]; then
-        CE_HOST_GCC=/opt/compiler-explorer/gcc-8.5.0
+    if [[ "${MAJOR}" -le 7 ]]; then
+        CE_HOST_GCC=/opt/compiler-explorer/gcc-7.5.0
     else
-        CE_HOST_GCC=/opt/compiler-explorer/gcc-9.4.0
+        CE_HOST_GCC=/opt/compiler-explorer/gcc-8.5.0
     fi
     if [[ ! -d "${CE_HOST_GCC}" ]]; then
         echo "ERROR: CE host gcc not found at ${CE_HOST_GCC} (required to build gcc ${MAJOR})"


### PR DESCRIPTION
SS_Stack was introduced in gcc 8's Ada runtime and `bindgen.adb`, so gcc-8.5.0's gnatbind generates SS_Stack references — incompatible with gcc 5-7 Ada runtimes.

Correct version bands (empirically verified from installed `.ali` files in S3 tarballs and gcc git history):
- **MAJOR ≤ 7** → `gcc-7.5.0` host (bindgen predates SS_Stack; compatible with gcc 5-7)
- **MAJOR 8–10** → `gcc-8.5.0` host (bindgen has SS_Stack; no `__gnat_begin_handler_v1`)

Replaces `gcc-9.4.0` with `gcc-7.5.0` in the Dockerfile — two host compilers, same structure as before.

🤖 Generated by LLM (Claude, via OpenClaw)