### PR TITLE
Fix gcc 8 Ada link failure and gcc 8.1-8.3/9.1-9.3 sanitizer ipc_perm assert

### DIFF
--- a/build/build.sh
+++ b/build/build.sh
@@ -326,11 +326,26 @@ if [[ "${MAJOR}" =~ ^[0-9]+$ ]] && [[ "${MAJOR}" -le 10 ]]; then
     echo "Using CE ${CE_HOST_GCC##*/} as host for gcc-${MAJOR}"
     export PATH="${CE_HOST_GCC}/bin:${PATH}"
     export LD_LIBRARY_PATH="${CE_HOST_GCC}/lib64:${CE_HOST_GCC}/lib:${LD_LIBRARY_PATH:-}"
-    export CC="${CE_HOST_GCC}/bin/gcc"
-    export CXX="${CE_HOST_GCC}/bin/g++"
+    # Wrap CC/CXX to force -gz=zlib debug compression.  Ubuntu 24.04's
+    # system assembler defaults to zstd, but the CE-installed host gcc's
+    # bundled ld is old enough that it cannot decompress zstd debug sections,
+    # causing "file not recognized" errors when linking Ada bootstrap objects.
+    GNAT_WRAPPER_DIR="$(mktemp -d)"
+    cat > "${GNAT_WRAPPER_DIR}/host-gcc" << 'WRAPPER_EOF'
+#!/bin/bash
+exec "@@CE_HOST_GCC@@/bin/gcc" -gz=zlib "$@"
+WRAPPER_EOF
+    cat > "${GNAT_WRAPPER_DIR}/host-g++" << 'WRAPPER_EOF'
+#!/bin/bash
+exec "@@CE_HOST_GCC@@/bin/g++" -gz=zlib "$@"
+WRAPPER_EOF
+    sed -i "s|@@CE_HOST_GCC@@|${CE_HOST_GCC}|g" \
+        "${GNAT_WRAPPER_DIR}/host-gcc" "${GNAT_WRAPPER_DIR}/host-g++"
+    chmod +x "${GNAT_WRAPPER_DIR}/host-gcc" "${GNAT_WRAPPER_DIR}/host-g++"
+    export CC="${GNAT_WRAPPER_DIR}/host-gcc"
+    export CXX="${GNAT_WRAPPER_DIR}/host-g++"
     # Shadow x86_64-linux-gnu-gnat* with the host's gnat tools so the Ada
     # bootstrap uses the same gnat version as the C/C++ host above.
-    GNAT_WRAPPER_DIR="$(mktemp -d)"
     for tool in gnat gnatbind gnatclean gnatfind gnatchop gnatkr gnatlink gnatls gnatmake gnatname gnatprep gnatxref; do
         if [[ -f "${CE_HOST_GCC}/bin/${tool}" ]]; then
             ln -sf "${CE_HOST_GCC}/bin/${tool}" "${GNAT_WRAPPER_DIR}/x86_64-linux-gnu-${tool}"

--- a/build/patches/gcc8.1/sanitizer-ipc-perm-glibc231.patch
+++ b/build/patches/gcc8.1/sanitizer-ipc-perm-glibc231.patch
@@ -1,0 +1,1 @@
+../sanitizer-ipc-perm-glibc231.patch

--- a/build/patches/gcc8.2/sanitizer-ipc-perm-glibc231.patch
+++ b/build/patches/gcc8.2/sanitizer-ipc-perm-glibc231.patch
@@ -1,0 +1,1 @@
+../sanitizer-ipc-perm-glibc231.patch

--- a/build/patches/gcc8.3/sanitizer-ipc-perm-glibc231.patch
+++ b/build/patches/gcc8.3/sanitizer-ipc-perm-glibc231.patch
@@ -1,0 +1,1 @@
+../sanitizer-ipc-perm-glibc231.patch

--- a/build/patches/gcc9.1/sanitizer-ipc-perm-glibc231.patch
+++ b/build/patches/gcc9.1/sanitizer-ipc-perm-glibc231.patch
@@ -1,0 +1,1 @@
+../sanitizer-ipc-perm-glibc231.patch

--- a/build/patches/gcc9.2/sanitizer-ipc-perm-glibc231.patch
+++ b/build/patches/gcc9.2/sanitizer-ipc-perm-glibc231.patch
@@ -1,0 +1,1 @@
+../sanitizer-ipc-perm-glibc231.patch

--- a/build/patches/gcc9.3/sanitizer-ipc-perm-glibc231.patch
+++ b/build/patches/gcc9.3/sanitizer-ipc-perm-glibc231.patch
@@ -1,0 +1,1 @@
+../sanitizer-ipc-perm-glibc231.patch

--- a/build/patches/sanitizer-ipc-perm-glibc231.patch
+++ b/build/patches/sanitizer-ipc-perm-glibc231.patch
@@ -1,0 +1,16 @@
+Fix __sanitizer_ipc_perm.mode size for glibc 2.31+.
+glibc 2.31 changed ipc_perm.mode from unsigned short (2 bytes) to
+unsigned int (4 bytes) on Linux x86/x86_64.  The sanitizer shadow
+struct must match or CHECK_SIZE_AND_OFFSET will fire at compile time.
+Fixed upstream in gcc 8.4.0 and gcc 9.4.0.
+--- a/libsanitizer/sanitizer_common/sanitizer_platform_limits_posix.h
++++ b/libsanitizer/sanitizer_common/sanitizer_platform_limits_posix.h
+@@ -231,8 +231,7 @@ extern unsigned struct_statvfs64_sz;
+ #else
+-    unsigned short mode;
+-    unsigned short __pad1;
+-    unsigned short __seq;
++    unsigned int mode;
++    unsigned short __seq;
+     unsigned short __pad2;
+ #if defined(__x86_64__) && !defined(_LP64)

--- a/build/patches/ucontext-struct.patch
+++ b/build/patches/ucontext-struct.patch
@@ -12,10 +12,11 @@ only 'ucontext_t'.  Fixed upstream in gcc 5.5.0, 6.5.0, and 7.5.0.
        /* The void * cast is necessary to avoid an aliasing warning.
           The aliasing warning is correct, but should not be a problem
           because it does not alias anything.  */
-@@ -138,7 +138,7 @@ x86_fallback_frame_state (struct _Unwind_Context *context,
+@@ -138,8 +138,8 @@ x86_fallback_frame_state (struct _Unwind_Context *context,
  	int sig;
  	siginfo_t *pinfo;
  	void *puc;
+ 	siginfo_t info;
 -	struct ucontext uc;
 +	ucontext_t uc;
        } *rt_ = context->cfa;


### PR DESCRIPTION
Two fixes for Ubuntu 24.04 build failures in gcc 8-9:

**gcc 8.x — Ada bootstrap link failure**
Ubuntu 24.04's system `as` defaults to zstd debug compression (binutils 2.42+). CE gcc-8.5.0's bundled `ld` is old enough that it cannot decompress zstd sections, causing `b_gnatl.o: file not recognized` when linking Ada tools.

Fix: wrap `CC`/`CXX` in build.sh to always pass `-gz=zlib`, forcing zlib compression which the old bundled `ld` can decompress.

**gcc 8.1–8.3 / 9.1–9.3 — libsanitizer compile-time assert**
glibc 2.31 changed `ipc_perm.mode` from `unsigned short` (2 bytes) to `unsigned int` (4 bytes) on x86/x86_64. The sanitizer shadow struct `CHECK_SIZE_AND_OFFSET(ipc_perm, mode)` fires at compile time.

Fixed upstream in gcc 8.4.0 and gcc 9.4.0. Patch applied to 8.1–8.3 and 9.1–9.3 via per-minor symlinks.

🤖 Generated by LLM (Claude, via OpenClaw)