### PR TITLE
Fix ucontext-struct.patch: add missing siginfo_t info context line

### DIFF
--- a/build/patches/ucontext-struct.patch
+++ b/build/patches/ucontext-struct.patch
@@ -12,10 +12,11 @@ only 'ucontext_t'.  Fixed upstream in gcc 5.5.0, 6.5.0, and 7.5.0.
        /* The void * cast is necessary to avoid an aliasing warning.
           The aliasing warning is correct, but should not be a problem
           because it does not alias anything.  */
-@@ -138,7 +138,7 @@ x86_fallback_frame_state (struct _Unwind_Context *context,
+@@ -138,8 +138,8 @@ x86_fallback_frame_state (struct _Unwind_Context *context,
  	int sig;
  	siginfo_t *pinfo;
  	void *puc;
+ 	siginfo_t info;
 -	struct ucontext uc;
 +	ucontext_t uc;
        } *rt_ = context->cfa;


### PR DESCRIPTION
Hunk #2 of `ucontext-struct.patch` was missing the `siginfo_t info;` context line between `void *puc;` and `struct ucontext uc;`. The struct has four fields in order: `int sig`, `siginfo_t *pinfo`, `void *puc`, `siginfo_t info`, then `struct ucontext uc`. Omitting `siginfo_t info;` from the context caused patch to fail on gcc 6.x and 7.x when fuzzy matching couldn't span the gap.

🤖 Generated by LLM (Claude, via OpenClaw)