### PR TITLE
Use --enable-checking=release for non-assertions builds

### DIFF
--- a/build/build.sh
+++ b/build/build.sh
@@ -200,10 +200,16 @@ else
 fi
 
 ## If version is prefixed by "assertions-", do the extra steps we want for the
-## assertions- builds.
+## assertions- builds. Otherwise, explicitly use --enable-checking=release so
+## that trunk builds behave like distro GCC (Ubuntu/Debian use release checking)
+## rather than defaulting to the expensive dev checks (--enable-checking=yes,extra)
+## that GCC trunk enables by default. The dev checks significantly slow down
+## compilation without affecting code generation.
 if [[ "${ORIG_VERSION}" == assertions-* ]]; then
     VERSION="assertions-${VERSION}"
     CONFIG+=" --enable-checking=yes,rtl,extra"
+else
+    CONFIG+=" --enable-checking=release"
 fi
 
 FULLNAME=gcc-${VERSION}


### PR DESCRIPTION
## Problem

GCC trunk defaults to `--enable-checking=yes,extra` for development builds, enabling expensive internal consistency checks (`tree`, `gimple`, `gc`, `misc`, `rtlflag`, `types`, `extra`). These checks significantly slow down compilation **without affecting generated code**.

This was reported on Mastodon: users noticed `#include <print>` taking ~10s on CE's gcc-trunk vs ~2.5s with a locally-built gcc-trunk: <https://hachyderm.io/@oschonrock@mastodon.social/116217760061260587>

Ubuntu explicitly switched their GCC packages to `--enable-checking=release` in 2010 because it ["significantly slows down the compiler"](https://bugs.launchpad.net/ubuntu/+source/gcc-4.5/+bug/612822). All major distros ship GCC with release checking. CE's gcc-trunk was silently using the expensive dev defaults instead.

## Fix

Explicitly set `--enable-checking=release` for all non-assertions builds. This was a conscious decision: the `assertions-*` builds (added per compiler-explorer/compiler-explorer#7115) already exist precisely for users who want GCC's internal self-checks (`--enable-checking=yes,rtl,extra`). The regular trunk should behave like what users have locally.

## Impact

- **`gcc-snapshot` (trunk)**: picks up the fix automatically on next nightly rebuild
- **Numbered releases**: already default to `--enable-checking=release` on release branches — the explicit flag is a safety net but no behaviour change for them
- **`assertions-*` builds**: completely unchanged
- **Generated code**: identical — `--enable-checking` only validates GCC's own internal data structures

*(I'm Molty, an AI assistant acting on behalf of @mattgodbolt)*